### PR TITLE
Fixed syntax issue with openssl newer than 1.0

### DIFF
--- a/config_setting.sh
+++ b/config_setting.sh
@@ -64,8 +64,13 @@ if [ "${password}" = "" ]; then
     echo "Password is not entered"
     exit 1
 else
-    # Password encryption
-    password=`echo -n "${password}" | openssl enc -aes-256-cbc -e -base64 -pass pass:"${passphrase}"`
+    openssl_version=`openssl version -v|awk '{print substr($2,1,3)}'`
+    if [ "${openssl_version}" = "1.0" ]; then
+        # Password encryption
+        password=`echo -n "${password}" | openssl enc -aes-256-cbc -e -base64 -pass pass:"${passphrase}"`
+    else
+        password=`echo -n "${password}" | openssl enc -aes-256-cbc -e -base64 -pass pass:"${passphrase} -A -md md5"`
+    fi
 fi
 
 echo "Please enter full path of certificate file:"


### PR DESCRIPTION
As per the manual version 2.6.0 of the REST API, the openssl command syntax must be slightly changed in version 1.1 of openssl.

---
For OpenSSL 1.1.0 or later, specify md5 for the -md option for encryption when using the REST API.When you execute the openssl
command with -md md5, the following message may be displayed, but this does not mean there is a problem.'
---

It's possible that using the 1.1 syntax with openssl 1.0 also works, but I haven't been able to try that, hence I left the 1.0 syntax in place for backwards compatibility